### PR TITLE
Allow duck typing for is_future check

### DIFF
--- a/promise.py
+++ b/promise.py
@@ -1,15 +1,4 @@
-try:
-    from asyncio import Future as AsyncioFuture
-except ImportError:
-    AsyncioFuture = None
-try:
-    from concurrent.futures import Future as ConcurrentFuture
-except ImportError:
-    ConcurrentFuture = None
 from threading import Event, RLock
-
-
-future_classes = tuple(filter(None, (AsyncioFuture, ConcurrentFuture)))
 
 
 class CountdownLatch(object):
@@ -423,7 +412,7 @@ def _process_future_result(promise):
 
 
 def is_future(obj):
-    return isinstance(obj, future_classes)
+    return hasattr(obj, "add_done_callback") and callable(getattr(obj, "add_done_callback"))
 
 
 def is_thenable(obj):


### PR DESCRIPTION
We are using a Future that is not neither a `ConcurrentFuture` or an `AsyncIOFuture`, but a GRPC future (https://github.com/grpc/grpc/blob/d0fbba52d6e379b76a69016bc264b96a2318315f/src/python/grpcio/grpc/framework/foundation/future.py#L63). This allows for any Future that implements `add_done_callback` to be used and resolves our issue.