### PR TITLE
Make Promise subclassable using classmethods, add asyncio await support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 - 3.5
 cache: pip
 install:
-- pip install pytest pytest-cov coveralls flake8
+- pip install pytest pytest-cov pytest-asyncio coveralls flake8
 - pip install futures
 - pip install -e .
 script:

--- a/README.md
+++ b/README.md
@@ -71,10 +71,18 @@ p = Promise.all([Promise.resolve('a'), 'b', Promise.resolve('c')]) \
 assert p.value is True
 ```
 
-### Promise.promisify(obj)
+#### Promise.promisify(obj)
 
 This function wraps the `obj` act as a `Promise` if possible.
 Python `Future`s are supported, with a callback to `promise.done` when resolved.
+
+
+#### Promise.promise_for_dict(d)
+
+A special function that takes a dictionary of promises and turns them
+into a promise for a dictionary of values.  In other words, this turns
+an dictionary of promises for values into a promise for a dictionary
+of values.
 
 
 ### Instance Methods

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ p = Promise.all([Promise.resolve('a'), 'b', Promise.resolve('c')]) \
 assert p.value is True
 ```
 
+### Promise.promisify(obj)
+
+This function wraps the `obj` act as a `Promise` if possible.
+Python `Future`s are supported, with a callback to `promise.done` when resolved.
+
+
 ### Instance Methods
 
 These methods are invoked on a promise instance by calling `myPromise.methodName`
@@ -98,12 +104,6 @@ The same semantics as `.then` except that it does not return a promise and any e
 ### is_thenable(obj)
 
 This function checks if the `obj` is a `Promise`, or could be `promisify`ed.
-
-
-### promisify(obj)
-
-This function wraps the `obj` act as a `Promise` if possible.
-Python `Future`s are supported, with a callback to `promise.done` when resolved.
 
 
 # Notes

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This creates and returns a new promise.  `resolver` must be a function.  The `re
 
 Converts values and foreign promises into Promises/A+ promises.  If you pass it a value then it returns a Promise for that value.  If you pass it something that is close to a promise (such as a jQuery attempt at a promise) it returns a Promise that takes on the state of `value` (rejected or fulfilled).
 
-#### Promise.reject(value)
+#### Promise.rejected(value)
 
 Returns a rejected promise with the given value.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This creates and returns a new promise.  `resolver` must be a function.  The `re
  1. `resolve` should be called with a single argument.  If it is called with a non-promise value then the promise is fulfilled with that value.  If it is called with a promise (A) then the returned promise takes on the state of that new promise (A).
  2. `reject` should be called with a single argument.  The returned promise will be rejected with that argument.
 
-### Static Functions
+### Class Methods
 
   These methods are invoked by calling `Promise.methodName`.
 

--- a/promise.py
+++ b/promise.py
@@ -59,6 +59,12 @@ class Promise(object):
         if fn:
             self.do_resolve(fn)
 
+    def __iter__(self):
+        yield self.get()
+
+    def __await__(self):
+        yield self.get()
+
     def do_resolve(self, fn):
         self._done = False
 

--- a/promise.py
+++ b/promise.py
@@ -115,7 +115,7 @@ class Promise(object):
 
     def _fulfill(self, value):
         with self._cb_lock:
-            if self._state != Promise.PENDING:
+            if self._state != self.PENDING:
                 return
 
             self._value = value
@@ -147,7 +147,7 @@ class Promise(object):
         assert isinstance(reason, Exception)
 
         with self._cb_lock:
-            if self._state != Promise.PENDING:
+            if self._state != self.PENDING:
                 return
 
             self._reason = reason

--- a/promise.py
+++ b/promise.py
@@ -455,6 +455,10 @@ class Promise(object):
         return cls.all(values).then(handleSuccess)
 
 
+promisify = Promise.promisify
+promise_for_dict = Promise.promise_for_dict
+
+
 def _process_future_result(promise):
     def handle_future_result(future):
         exception = future.exception()

--- a/promise.py
+++ b/promise.py
@@ -84,15 +84,15 @@ class Promise(object):
         except Exception as e:
             self.reject(e)
 
-    @staticmethod
-    def fulfilled(x):
-        p = Promise()
+    @classmethod
+    def fulfilled(cls, x):
+        p = cls()
         p.fulfill(x)
         return p
 
-    @staticmethod
-    def rejected(reason):
-        p = Promise()
+    @classmethod
+    def rejected(cls, reason):
+        p = cls()
         p.reject(reason)
         return p
 
@@ -327,7 +327,7 @@ class Promise(object):
         :type failure: (object) -> object
         :rtype : Promise
         """
-        ret = Promise()
+        ret = self.__class__()
 
         def call_and_fulfill(v):
             """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+
+collect_ignore = []
+if sys.version_info[:2] < (3, 4):
+    collect_ignore.append('test_awaitable.py')
+if sys.version_info[:2] < (3, 5):
+    collect_ignore.append('test_awaitable_35.py')

--- a/tests/test_awaitable.py
+++ b/tests/test_awaitable.py
@@ -1,11 +1,5 @@
-import pytest
-import sys
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 4),
-    reason='asyncio not available before Python 3.4'
-)  # noqa: ignore statement before import warning
-
 import asyncio
+import pytest
 from promise import Promise
 
 

--- a/tests/test_awaitable.py
+++ b/tests/test_awaitable.py
@@ -1,0 +1,15 @@
+import pytest
+import sys
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 4),
+    reason='asyncio not available before Python 3.4'
+)  # noqa: ignore statement before import warning
+
+import asyncio
+from promise import Promise
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_await():
+    yield from Promise.resolve(None)

--- a/tests/test_awaitable_35.py
+++ b/tests/test_awaitable_35.py
@@ -1,0 +1,13 @@
+import pytest
+import sys
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 5),
+    reason='async/await syntax not available before Python 3.5'
+)  # noqa: ignore statement before import warning
+
+from promise import Promise
+
+
+@pytest.mark.asyncio
+async def test_await():
+    await Promise.resolve(None)

--- a/tests/test_awaitable_35.py
+++ b/tests/test_awaitable_35.py
@@ -1,10 +1,4 @@
 import pytest
-import sys
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 5),
-    reason='async/await syntax not available before Python 3.5'
-)  # noqa: ignore statement before import warning
-
 from promise import Promise
 
 

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -3,7 +3,7 @@
 import time
 import pytest
 
-from promise import Promise, promise_for_dict, is_thenable, promisify
+from promise import Promise, promise_for_dict, is_thenable
 from concurrent.futures import Future
 from threading import Thread
 
@@ -414,26 +414,26 @@ def test_is_thenable_simple_object():
 
 def test_promisify_promise():
     promise = Promise()
-    assert promisify(promise) == promise
+    assert Promise.promisify(promise) == promise
 
 
 def test_promisify_then_object():
     promise = FakeThenPromise()
     with pytest.raises(Exception) as excinfo:
-        promisify(promise)
+        Promise.promisify(promise)
     assert str(excinfo.value) == "FakeThenPromise raises in 'then'"
 
 
 def test_promisify_done_object():
     promise = FakeDonePromise()
     with pytest.raises(Exception) as excinfo:
-        promisify(promise)
+        Promise.promisify(promise)
     assert str(excinfo.value) == "FakeDonePromise raises in 'done'"
 
 
 def test_promisify_future():
     future = Future()
-    promise = promisify(future)
+    promise = Promise.promisify(future)
     assert promise.is_pending
     future.set_result(1)
     assert promise.is_fulfilled
@@ -442,7 +442,7 @@ def test_promisify_future():
 
 def test_promisify_future_rejected():
     future = Future()
-    promise = promisify(future)
+    promise = Promise.promisify(future)
     assert promise.is_pending
     future.set_exception(Exception('Future rejected'))
     assert promise.is_rejected
@@ -451,5 +451,5 @@ def test_promisify_future_rejected():
 
 def test_promisify_object():
     with pytest.raises(TypeError) as excinfo:
-        promisify(object())
+        Promise.promisify(object())
     assert str(excinfo.value) == "Object is not a Promise like object."

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -3,7 +3,7 @@
 import time
 import pytest
 
-from promise import Promise, promise_for_dict, is_thenable
+from promise import Promise, is_thenable
 from concurrent.futures import Future
 from threading import Thread
 
@@ -241,9 +241,9 @@ def test_dict_promise_when():
     p1 = Promise()
     p2 = Promise()
     d = {"a": p1, "b": p2}
-    pd1 = promise_for_dict(d)
-    pd2 = promise_for_dict({"a": p1})
-    pd3 = promise_for_dict({})
+    pd1 = Promise.promise_for_dict(d)
+    pd2 = Promise.promise_for_dict({"a": p1})
+    pd3 = Promise.promise_for_dict({})
     assert p1.is_pending
     assert p2.is_pending
     assert pd1.is_pending
@@ -271,7 +271,7 @@ def test_dict_promise_if():
     p1 = Promise()
     p2 = Promise()
     d = {"a": p1, "b": p2}
-    pd = promise_for_dict(d)
+    pd = Promise.promise_for_dict(d)
     assert p1.is_pending
     assert p2.is_pending
     assert pd.is_pending


### PR DESCRIPTION
These commits make the following changes to the code, reflecting them in the tests and docs.

- `Promise.fulfilled`/`resolve`, `Promise.rejected`, and `Promise.all` were converted from `staticmethod`s to `classmethod`s, allowing them to invoke constructors and other `classmethod`s via `cls()` and `cls.<method>` rather than `Promise()` and `Promise.<method>`. Additionally class atttributes are now referenced using `self.<attribute>` rather than `Promise.<attribute>`. This improves support for classes which inherit from `Promise`, since if client code defines a subclass `SpecialPromise` then calling e.g. `SpecialPromise.all` or `SpecialPromise().then()` will now return a `SpecialPromise` instance rather than a `Promise` instance.

- `promisify` and `promise_for_dict` were made into `classmethod`s rather than free functions for the same reason. To preserve API compatibility we also alias `promisify = Promise.promisify` and `promise_for_dict = Promise.promise_for_dict`. Parameterized test fixtures were added to run tests against both the classmethod and the free function versions.

- `__iter__` and `__await__` methods were added to let Python 3.4 and 3.5 code `yield from` or `await` a `Promise` in asynchronous code. This makes working with `Promise`s feel more native when using `asyncio` and aligns with ES7's `async`/`await` behavior for native promises. I have not tried to test this against the backported `asyncio` library for Python 3.3 but it should work fine since new syntax is not used anywhere in the library, only in tests. 

- A `conftest.py` was added to skip tests involving the async/await behavior on Python versions that do not support it.

- `Promise.promise_for_dict` was added to the documentation, with a description directly copied from its docstring.

- The documentation has been changed to indicate that the class method for creating a failed `Promise` is called `Promise.rejected` rather than `Promise.reject` -- the latter is an instance method.