### PR TITLE
Catch ImportError for iterate_promise

### DIFF
--- a/promise/compat.py
+++ b/promise/compat.py
@@ -13,6 +13,6 @@ except ImportError:
 
 try:
     from .iterate_promise import iterate_promise
-except SyntaxError:
+except (SyntaxError, ImportError):
     def iterate_promise(promise):
         raise Exception('You need "yield from" syntax for iterate in a Promise.')


### PR DESCRIPTION
In our environment we compile each third_party package for Python 2.7 so when it tries to compile the `iterate_promise` module it throws an exception. This change allows us tor remove the file before compiling and use the latest version.