### PR TITLE
Fix Promise.all hanging in certain cases

### DIFF
--- a/promise/promise.py
+++ b/promise/promise.py
@@ -398,6 +398,9 @@ class Promise(object):
         In other words, this turns an list of promises for values
         into a promise for a list of values.
         """
+        if len(values_or_promises) == 0:
+            return cls.fulfilled(values_or_promises)
+            
         promises = (cls.promisify(v_or_p) if is_thenable(v_or_p) else cls.resolve(v_or_p) for
                     v_or_p in values_or_promises)
 
@@ -412,8 +415,6 @@ class Promise(object):
 
         for i, p in enumerate(promises):
             p.done(functools.partial(handle_success, i), all_promise.reject)
-        else:
-            all_promise.fulfill([])
 
         return all_promise
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -400,7 +400,7 @@ class Promise(object):
         """
         if len(values_or_promises) == 0:
             return cls.fulfilled(values_or_promises)
-            
+
         promises = (cls.promisify(v_or_p) if is_thenable(v_or_p) else cls.resolve(v_or_p) for
                     v_or_p in values_or_promises)
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -412,6 +412,8 @@ class Promise(object):
 
         for i, p in enumerate(promises):
             p.done(functools.partial(handle_success, i), all_promise.reject)
+        else:
+            all_promise.fulfill([])
 
         return all_promise
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -1,3 +1,4 @@
+import functools
 from threading import Event, RLock
 from .compat import Future, iscoroutine, ensure_future, iterate_promise
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -397,21 +397,20 @@ class Promise(object):
         In other words, this turns an list of promises for values
         into a promise for a list of values.
         """
-        promises = list(filter(is_thenable, values_or_promises))
-        if len(promises) == 0:
-            # All the values or promises are resolved
-            return cls.fulfilled(values_or_promises)
+        promises = (cls.promisify(v_or_p) if is_thenable(v_or_p) else cls.resolve(v_or_p) for
+                    v_or_p in values_or_promises)
 
         all_promise = cls()
-        counter = CountdownLatch(len(promises))
+        counter = CountdownLatch(len(values_or_promises))
+        values = [None] * len(values_or_promises)
 
-        def handle_success(_):
+        def handle_success(original_position, value):
+            values[original_position] = value
             if counter.dec() == 0:
-                values = list(map(lambda p: p.value if p in promises else p, values_or_promises))
                 all_promise.fulfill(values)
 
-        for p in promises:
-            cls.promisify(p).done(handle_success, all_promise.reject)
+        for i, p in enumerate(promises):
+            p.done(functools.partial(handle_success, i), all_promise.reject)
 
         return all_promise
 


### PR DESCRIPTION
This is an issue very difficult to reproduce and it just happened in our live system. We are using GRPC, which returns us their own implementation of a `Future` (called `_Rendezvous`) and for some reason in some rare case, using `Promise.all` (as well as `Promise.for_dict`) the entire graphql request would hang. I have managed to boil it down to this line: https://github.com/syrusakbary/promise/blob/master/promise/promise.py#L410, specifically to the statement `if p in promises`. We have not been able to figure out why exactly it hangs on this comparison statement, but it might have something to do with the fact that we are using grpc futures under the hood (which have been promisified).

It was easy enough to rewrite this function to not have any comparison at all. We are using this patched version now in our live system so would be great to get it in (or some other way that does not need the `p in promises` comparison).