### PR TITLE
Add Traceback support to thrown Exceptions

### DIFF
--- a/promise/promise.py
+++ b/promise/promise.py
@@ -1,7 +1,7 @@
 import functools
 from threading import Event, RLock
 from .compat import Future, iscoroutine, ensure_future, iterate_promise  # type: ignore
-from future.utils import raise_
+from six import reraise as raise_
 from typing import Callable, Optional, Iterator, Any, Dict, Tuple, Union  # flake8: noqa
 
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -145,6 +145,11 @@ class Promise(object):
                                                "Got %s" % reason)
 
         with self._cb_lock:
+            import sys
+            e_type, value, traceback = sys.exc_info()
+            if e_type:
+                reason.traceback = traceback
+
             if self.state != self.PENDING:
                 return
 
@@ -197,7 +202,7 @@ class Promise(object):
             raise ValueError("Value not available, promise is still pending")
         elif self.state == self.FULFILLED:
             return self.value
-        raise self.reason
+        raise type(self.reason), self.reason, getattr(self.reason, 'traceback', None)
 
     def wait(self, timeout=None):
         # type: (Promise, int) -> None
@@ -211,7 +216,7 @@ class Promise(object):
     def add_callback(self, f):
         # type: (Promise, Callable) -> None
         """
-        Add a callback for when this promis is fulfilled.  Note that
+        Add a callback for when this promise is fulfilled.  Note that
         if you intend to use the value of the promise somehow in
         the callback, it is more convenient to use the 'then' method.
         """

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -146,9 +146,9 @@ class Promise(object):
 
         with self._cb_lock:
             import sys
-            e_type, value, traceback = sys.exc_info()
-            if e_type:
-                reason.traceback = traceback
+            _, __, tb = sys.exc_info()
+            if tb is not None and not hasattr(reason, '__traceback__'):
+                reason.__traceback__ = tb
 
             if self.state != self.PENDING:
                 return
@@ -203,7 +203,7 @@ class Promise(object):
         elif self.state == self.FULFILLED:
             return self.value
 
-        raise_(type(self.reason), self.reason, getattr(self.reason, 'traceback', None))
+        raise_(type(self.reason), self.reason, getattr(self.reason, '__traceback__', None))
 
     def wait(self, timeout=None):
         # type: (Promise, int) -> None

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -1,7 +1,7 @@
 import functools
 from threading import Event, RLock
 from .compat import Future, iscoroutine, ensure_future, iterate_promise  # type: ignore
-
+from future.utils import raise_
 from typing import Callable, Optional, Iterator, Any, Dict, Tuple, Union  # flake8: noqa
 
 
@@ -202,7 +202,8 @@ class Promise(object):
             raise ValueError("Value not available, promise is still pending")
         elif self.state == self.FULFILLED:
             return self.value
-        raise type(self.reason), self.reason, getattr(self.reason, 'traceback', None)
+
+        raise_(type(self.reason), self.reason, getattr(self.reason, 'traceback', None))
 
     def wait(self, timeout=None):
         # type: (Promise, int) -> None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
 exclude = tests,scripts,setup.py,docs
 max-line-length = 120
+[aliases]
+test=pytest
+[tool:pytest]
+addopts = --verbose

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     keywords='concurrent future deferred promise',
     packages=["promise"],
     install_requires=[
-        'typing',
+        'typing', 'future'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest>=2.7.3', 'futures'],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     keywords='concurrent future deferred promise',
     packages=["promise"],
     install_requires=[
-        'typing', 'future'
+        'typing', 'six'
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest>=2.7.3', 'futures'],

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
     install_requires=[
         'typing',
     ],
+    setup_requires=['pytest-runner'],
     tests_require=['pytest>=2.7.3', 'futures'],
 )

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -108,6 +108,11 @@ def test_exceptions():
     with pytest.raises(Exception) as excinfo:
         p2.get()
 
+    p3 = Promise.resolve('a').then(throws)
+    with pytest.raises(AssertionError) as assert_exc:
+        p3.get()
+    assert hasattr(assert_exc, 'traceback')
+
 
 def test_fake_promise():
     p = Promise()


### PR DESCRIPTION
I wanted to be able to see the traceback of where the promise was rejected during a p.get()

- This maintains the traceback if there was a thrown Exception in the reason. 
- On p.get(), I added a raise with the original traceback to see where the ACTUAL traceback occurred -- not the traceback of the p.get()
- added tests to demonstrate the addition of a 'traceback' attribute to the reason exception

I didn't see instructions on how to run the tests so i updated setup.py to run pytest with **python setup.py test**