### PR TITLE
Start resolver in new thread, to replicate node.js Promise behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Returns a promise for a list.  If it is called with a single argument then this 
 p = Promise.all([Promise.resolve('a'), 'b', Promise.resolve('c')]) \
        .then(lambda res: res == ['a', 'b', 'c'])
 
-assert p.value is True
+assert p.get() is True
 ```
 
 #### Promise.promisify(obj)

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ replaced by their fulfilled values. e.g.
     p = Promise.all([Promise.resolve('a'), 'b', Promise.resolve('c')]) \
            .then(lambda res: res == ['a', 'b', 'c'])
 
-    assert p.value is True
+    assert p.get() is True
 
 Promise.promisify(obj)
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -460,13 +460,12 @@ class Promise(object):
         if not m:
             return cls.fulfilled({})
 
-        keys, values = zip(*m.items())
         dict_type = type(m)
 
         def handle_success(resolved_values):
-            return dict_type(zip(keys, resolved_values))
+            return dict_type(zip(m.keys(), resolved_values))
 
-        return cls.all(values).then(handle_success)
+        return cls.all(m.values()).then(handle_success)
 
 
 promisify = Promise.promisify

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -191,7 +191,7 @@ class Promise(object):
         return self.state == self.REJECTED
 
     def get(self, timeout=None):
-        # type: (Promise, int) -> Any
+        # type: (Promise, float) -> Any
         """Get the value of the promise, waiting if necessary."""
         if timeout is None and version_info[0] == 2:
             self.wait(float("Inf"))
@@ -205,7 +205,7 @@ class Promise(object):
         raise self.reason
 
     def wait(self, timeout=None):
-        # type: (Promise, int) -> None
+        # type: (Promise, float) -> None
         """
         An implementation of the wait method which doesn't involve
         polling but instead utilizes a "real" synchronization

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -1,8 +1,8 @@
-import functools
+from functools import partial
 from threading import Thread, Event, RLock
 from .compat import Future, iscoroutine, ensure_future, iterate_promise  # type: ignore
 
-from typing import Callable, Optional, Iterator, Any, Dict, Tuple, Union  # flake8: noqa
+from typing import Callable, Optional, Iterator, Any, Dict  # flake8: noqa
 
 
 class CountdownLatch(object):
@@ -143,7 +143,7 @@ class Promise(object):
         Reject this promise for a given reason.
         """
         assert isinstance(reason, Exception), ("The reject function needs to be called with an Exception. "
-                                               "Got %s" % reason)
+                                               "Got {}".format(reason))
 
         with self._cb_lock:
             if self.state != self.PENDING:
@@ -216,7 +216,7 @@ class Promise(object):
         if you intend to use the value of the promise somehow in
         the callback, it is more convenient to use the 'then' method.
         """
-        assert callable(f), "A function needs to be passed into add_callback. Got: %s" % f
+        assert callable(f), "A function needs to be passed into add_callback. Got: {}".format(f)
 
         with self._cb_lock:
             if self.state == self.PENDING:
@@ -237,7 +237,7 @@ class Promise(object):
         somehow in the callback, it is more convenient to use
         the 'then' method.
         """
-        assert callable(f), "A function needs to be passed into add_errback. Got: %s" % f
+        assert callable(f), "A function needs to be passed into add_errback. Got: {}".format(f)
 
         with self._cb_lock:
             if self.state == self.PENDING:
@@ -411,7 +411,7 @@ class Promise(object):
                 all_promise.fulfill(values)
 
         for i, p in enumerate(promises):
-            p.done(functools.partial(handle_success, i), all_promise.reject)  # type: ignore
+            p.done(partial(handle_success, i), all_promise.reject)  # type: ignore
 
         return all_promise
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -189,7 +189,7 @@ class Promise(object):
         """Indicate whether the Promise has been rejected. Could be wrong the moment the function returns."""
         return self.state == self.REJECTED
 
-    def get(self, timeout=None):
+    def get(self, timeout=float("Inf")):
         # type: (Promise, int) -> Any
         """Get the value of the promise, waiting if necessary."""
         self.wait(timeout)
@@ -200,7 +200,7 @@ class Promise(object):
             return self.value
         raise self.reason
 
-    def wait(self, timeout=None):
+    def wait(self, timeout=float("Inf")):
         # type: (Promise, int) -> None
         """
         An implementation of the wait method which doesn't involve

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-import sys
+from sys import version_info
 
 collect_ignore = []
-if sys.version_info[:2] < (3, 4):
+if version_info[:2] < (3, 4):
     collect_ignore.append('test_awaitable.py')
-if sys.version_info[:2] < (3, 5):
+if version_info[:2] < (3, 5):
     collect_ignore.append('test_awaitable_35.py')

--- a/tests/test_awaitable.py
+++ b/tests/test_awaitable.py
@@ -1,20 +1,20 @@
-import asyncio
-import pytest
-import time
+from asyncio import coroutine
+from pytest import mark
+from time import sleep
 from promise import Promise
 
 
-@pytest.mark.asyncio
-@asyncio.coroutine
+@mark.asyncio
+@coroutine
 def test_await():
     yield from Promise.resolve(True)
 
 
-@pytest.mark.asyncio
-@asyncio.coroutine
+@mark.asyncio
+@coroutine
 def test_await_time():
     def resolve_or_reject(resolve, reject):
-        time.sleep(.1)
+        sleep(.1)
         resolve(True)
     p = Promise(resolve_or_reject)
     assert p.get() is True

--- a/tests/test_awaitable_35.py
+++ b/tests/test_awaitable_35.py
@@ -1,33 +1,33 @@
-import pytest
-import asyncio
+from asyncio import sleep, Future
+from pytest import mark
 from promise import Promise, promisify, is_thenable
 
 
-@pytest.mark.asyncio
+@mark.asyncio
 async def test_await():
     assert await Promise.resolve(True)
 
 
-@pytest.mark.asyncio
+@mark.asyncio
 async def test_promisify_coroutine():
     async def my_coroutine():
-        await asyncio.sleep(.01)
+        await sleep(.01)
         return True
 
     assert await promisify(my_coroutine())
 
 
-@pytest.mark.asyncio
+@mark.asyncio
 async def test_coroutine_is_thenable():
     async def my_coroutine():
-        await asyncio.sleep(.01)
+        await sleep(.01)
         return True
 
     assert is_thenable(my_coroutine())
 
 
-@pytest.mark.asyncio
+@mark.asyncio
 async def test_promisify_future():
-    future = asyncio.Future()
+    future = Future()
     future.set_result(True)
     assert await promisify(future)

--- a/tests/test_complex_threads.py
+++ b/tests/test_complex_threads.py
@@ -1,14 +1,14 @@
-import time
-import concurrent.futures
+from time import sleep
+from concurrent.futures import ThreadPoolExecutor
 from promise import Promise
 from operator import mul
-executor = concurrent.futures.ThreadPoolExecutor(max_workers=40000);
+executor = ThreadPoolExecutor(max_workers=40000);
 
 
 def promise_factorial(n):
     if n < 2:
         return 1
-    time.sleep(.02)
+    sleep(.02)
     a = executor.submit(promise_factorial, n - 1)
     return Promise.promisify(a).then(lambda r: mul(r, n))
 

--- a/tests/test_complex_threads.py
+++ b/tests/test_complex_threads.py
@@ -1,11 +1,8 @@
 import time
 import concurrent.futures
 from promise import Promise
+from operator import mul
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=40000);
-
-
-def combine(r,n):
-    return r * n
 
 
 def promise_factorial(n):
@@ -13,7 +10,7 @@ def promise_factorial(n):
         return 1
     time.sleep(.02)
     a = executor.submit(promise_factorial, n - 1)
-    return Promise.promisify(a).then(lambda r: combine(r, n))
+    return Promise.promisify(a).then(lambda r: mul(r, n))
 
 
 def test_factorial():

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -1,7 +1,7 @@
 # This exercises some capabilities above and beyond
 # the Promises/A+ test suite
-import time
-import pytest
+from time import sleep
+from pytest import raises, fixture
 
 from promise import (
     Promise,
@@ -23,7 +23,7 @@ class DelayedFulfill(Thread):
         Thread.__init__(self)
 
     def run(self):
-        time.sleep(self.delay)
+        sleep(self.delay)
         self.promise.fulfill(self.value)
 
 
@@ -35,7 +35,7 @@ class DelayedRejection(Thread):
         Thread.__init__(self)
 
     def run(self):
-        time.sleep(self.delay)
+        sleep(self.delay)
         self.promise.reject(self.reason)
 
 
@@ -88,7 +88,7 @@ def test_rejected():
 # Fulfill
 def test_fulfill_self():
     p = Promise()
-    with pytest.raises(TypeError) as excinfo:
+    with raises(TypeError) as excinfo:
         p.fulfill(p)
 
 
@@ -105,7 +105,7 @@ def test_exceptions():
     p2.add_errback(throws)
     p2.reject(Exception())
 
-    with pytest.raises(Exception) as excinfo:
+    with raises(Exception) as excinfo:
         p2.get()
 
 
@@ -249,7 +249,7 @@ def test_promise_all_if():
 
 
 # promise_for_dict
-@pytest.fixture(params=[
+@fixture(params=[
     Promise.for_dict,
     free_promise_for_dict,
 ])
@@ -441,7 +441,7 @@ def test_is_thenable_simple_object():
     assert not is_thenable(object())
 
 
-@pytest.fixture(params=[free_promisify, Promise.promisify])
+@fixture(params=[free_promisify, Promise.promisify])
 def promisify(request):
     return request.param
 
@@ -459,7 +459,7 @@ def test_promisify_then_object(promisify):
 
 def test_promisify_then_object_exception(promisify):
     promise = FakeThenPromise()
-    with pytest.raises(Exception) as excinfo:
+    with raises(Exception) as excinfo:
         promisify(promise)
     assert str(excinfo.value) == "FakeThenPromise raises in 'then'"
 
@@ -472,7 +472,7 @@ def test_promisify_done_object(promisify):
 
 def test_promisify_done_object_exception(promisify):
     promise = FakeDonePromise()
-    with pytest.raises(Exception) as excinfo:
+    with raises(Exception) as excinfo:
         promisify(promise)
     assert str(excinfo.value) == "FakeDonePromise raises in 'done'"
 
@@ -496,7 +496,7 @@ def test_promisify_future_rejected(promisify):
 
 
 def test_promisify_object(promisify):
-    with pytest.raises(TypeError) as excinfo:
+    with raises(TypeError) as excinfo:
         promisify(object())
     assert str(excinfo.value) == "Object is not a Promise like object."
 

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -396,8 +396,8 @@ def test_then_all():
 
 def test_do_resolve():
     p1 = Promise(lambda resolve, reject: resolve(0))
+    assert p1.get() == 0
     assert p1.is_fulfilled
-    assert p1.value == 0
 
 
 def test_do_resolve_fail_on_call():
@@ -413,8 +413,8 @@ def test_catch():
     p2 = p1.then(lambda value: 1 / value) \
            .catch(lambda e: e) \
            .then(lambda e: type(e))
+    assert p2.get() == ZeroDivisionError
     assert p2.is_fulfilled
-    assert p2.value == ZeroDivisionError
 
 
 def test_is_thenable_promise():
@@ -482,8 +482,8 @@ def test_promisify_future(promisify):
     promise = promisify(future)
     assert promise.is_pending
     future.set_result(1)
+    assert promise.get() == 1
     assert promise.is_fulfilled
-    assert promise.value == 1
 
 
 def test_promisify_future_rejected(promisify):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,5 +1,7 @@
 # This tests reported issues in the Promise package
+from concurrent.futures import ThreadPoolExecutor
 from promise import Promise
+executor = ThreadPoolExecutor(max_workers=40000);
 
 
 def test_issue_11():
@@ -17,3 +19,15 @@ def test_issue_11():
 
     promise_rejected = test(-42).then(lambda x: x, lambda e: str(e))
     assert promise_rejected.get() == "-42"
+
+
+def identity(x):
+    return x
+
+
+def promise_something(x):
+    return Promise.promisify(executor.submit(identity, x));
+
+
+def test_issue_9():
+    assert Promise.all([promise_something(x).then(lambda y: x*y) for x in (0,1,2,3)]).get() == [0, 1, 4, 9]

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -4,16 +4,16 @@ from promise import Promise
 
 def test_issue_11():
     # https://github.com/syrusakbary/promise/issues/11
-    def test(x):                                                                
-        def my(resolve, reject):                                                  
-            if x > 0:                                                               
-                resolve(x)                                                            
-            else:                                                                   
-                reject(Exception(x))                                                            
-        return Promise(my)                                                        
+    def test(x):
+        def my(resolve, reject):
+            if x > 0:
+                resolve(x)
+            else:
+                reject(Exception(x))
+        return Promise(my)
 
     promise_resolved = test(42).then(lambda x: x)
-    assert promise_resolved.value == 42
+    assert promise_resolved.get() == 42
 
     promise_rejected = test(-42).then(lambda x: x, lambda e: str(e))
-    assert promise_rejected.value == "-42"
+    assert promise_rejected.get() == "-42"


### PR DESCRIPTION
This patch also makes some other minor changes:

* Python 2 default timeout is now `float("Inf")`, rather than `None`, so that it still listens to `KeyboardInterrupt`
* API doc is updated to reflect the code running asynchronously
* Imports were trimmed to grab only what's used
* String formatting now uses `"".format()`
* One test imports a stdlib function, rather than redefining it, as previously
* Test added for #9

From my testing, this should also fix #9