### PR TITLE
Fix await blocked by context exit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,4 @@ if version_info[:2] < (3, 4):
     collect_ignore.append('test_awaitable.py')
 if version_info[:2] < (3, 5):
     collect_ignore.append('test_awaitable_35.py')
+    collect_ignore.append('test_dataloader_awaitable_35.py')

--- a/tests/test_awaitable.py
+++ b/tests/test_awaitable.py
@@ -19,3 +19,14 @@ def test_await_time():
 
     p = Promise(resolve_or_reject)
     assert p.get() is True
+
+
+@mark.asyncio
+@coroutine
+def test_promise_coroutine():
+    @coroutine
+    def my_coro():
+        yield from Promise.resolve(True)
+
+    promise = Promise.resolve(my_coro())
+    assert isinstance(promise, Promise)

--- a/tests/test_awaitable_35.py
+++ b/tests/test_awaitable_35.py
@@ -1,5 +1,6 @@
 from asyncio import sleep, Future, wait, FIRST_COMPLETED
 from pytest import mark
+from promise.context import Context
 from promise import Promise, is_thenable
 
 
@@ -31,3 +32,16 @@ async def test_promisify_future():
     future = Future()
     future.set_result(True)
     assert await Promise.resolve(future)
+
+
+@mark.asyncio
+async def test_await_in_context():
+    async def inner():
+        with Context():
+            promise = Promise.resolve(True).then(lambda x: x)
+            return await promise
+
+    result = await inner()
+    assert result == True
+
+

--- a/tests/test_awaitable_35.py
+++ b/tests/test_awaitable_35.py
@@ -43,5 +43,3 @@ async def test_await_in_context():
 
     result = await inner()
     assert result == True
-
-

--- a/tests/test_dataloader_awaitable_35.py
+++ b/tests/test_dataloader_awaitable_35.py
@@ -19,12 +19,12 @@ def id_loader(**options):
 @mark.asyncio
 async def test_await_dataloader():
     identity_loader, load_calls = id_loader()
-    async def load_one_then_two(identity_loader):
+    async def load_multiple(identity_loader):
         one = identity_loader.load('load1')
         two = identity_loader.load('load2')
         return await Promise.all([one, two])
 
-    result = await load_one_then_two(identity_loader)
+    result = await load_multiple(identity_loader)
     assert result == ['load1', 'load2']
     assert load_calls == [['load1'], ['load2']]
 
@@ -34,10 +34,39 @@ async def test_await_dataloader_safe_promise():
     identity_loader, load_calls = id_loader()
 
     @Promise.safe
-    async def load_one_then_two(identity_loader):
+    async def load_multiple(identity_loader):
         one = identity_loader.load('load1')
         two = identity_loader.load('load2')
         return await Promise.all([one, two])
+
+    result = await load_multiple(identity_loader)
+    assert result == ['load1', 'load2']
+    assert load_calls == [['load1'], ['load2']]
+
+
+@mark.asyncio
+async def test_await_dataloader_individual():
+    identity_loader, load_calls = id_loader()
+
+    async def load_one_then_two(identity_loader):
+        one = await identity_loader.load('load1')
+        two = await identity_loader.load('load2')
+        return [one, two]
+
+    result = await load_one_then_two(identity_loader)
+    assert result == ['load1', 'load2']
+    assert load_calls == [['load1'], ['load2']]
+
+
+@mark.asyncio
+async def test_await_dataloader_individual_safe_promise():
+    identity_loader, load_calls = id_loader()
+
+    @Promise.safe
+    async def load_one_then_two(identity_loader):
+        one = await identity_loader.load('load1')
+        two = await identity_loader.load('load2')
+        return [one, two]
 
     result = await load_one_then_two(identity_loader)
     assert result == ['load1', 'load2']

--- a/tests/test_dataloader_awaitable_35.py
+++ b/tests/test_dataloader_awaitable_35.py
@@ -1,0 +1,44 @@
+from pytest import mark
+from promise import Promise
+from promise.dataloader import DataLoader
+
+
+def id_loader(**options):
+    load_calls = []
+
+    resolve = options.pop('resolve', Promise.resolve)
+
+    def fn(keys):
+        load_calls.append(keys)
+        return resolve(keys)
+    
+    identity_loader = DataLoader(fn, **options)
+    return identity_loader, load_calls
+
+
+@mark.asyncio
+async def test_await_dataloader():
+    identity_loader, load_calls = id_loader()
+    async def load_one_then_two(identity_loader):
+        one = identity_loader.load('load1')
+        two = identity_loader.load('load2')
+        return await Promise.all([one, two])
+
+    result = await load_one_then_two(identity_loader)
+    assert result == ['load1', 'load2']
+    assert load_calls == [['load1'], ['load2']]
+
+
+@mark.asyncio
+async def test_await_dataloader_safe_promise():
+    identity_loader, load_calls = id_loader()
+
+    @Promise.safe
+    async def load_one_then_two(identity_loader):
+        one = identity_loader.load('load1')
+        two = identity_loader.load('load2')
+        return await Promise.all([one, two])
+
+    result = await load_one_then_two(identity_loader)
+    assert result == ['load1', 'load2']
+    assert load_calls == [['load1'], ['load2']]


### PR DESCRIPTION
There was a blocking issue caused by an await call inside a Promise Context.
It was easily fixed by draining the context queue when iterating the future.

The newly added test `test_await_in_context` in tests/test_awaitable_35.py might showcase better this issue :)

@schrockn