### PR TITLE
dataloader: Fix clearing a missing value causing a KeyError and halting the event loop #29

### DIFF
--- a/promise/dataloader.py
+++ b/promise/dataloader.py
@@ -125,7 +125,7 @@ class DataLoader(object):
         method chaining.
         '''
         cache_key = self.get_cache_key(key)
-        del self._promise_cache[cache_key]
+        self._promise_cache.pop(cache_key, None)
         return self
 
     def clear_all(self):


### PR DESCRIPTION
Not sure if the tests are any good. If i run the test suite without the fix for "clear", the tests hang...