### PR TITLE
Removes typing dependency for Python3.5+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'test': tests_require,
     },
     install_requires=[
-        'typing>=3.6.4', 'six'
+        "typing>=3.6.4; python_version < '3.5'",
+        'six'
     ],
     tests_require=tests_require, )


### PR DESCRIPTION
Python 3.5 includes the typing module which doesn't appear to be
version compatible with the pip package of the same name.  Consequently,
the typing module is actually installed within a pip environment.  This
can cause problems for development when the pip version of the typing
module overrides the builtin version.
```

---------- coverage: platform darwin, python 3.7.0-final-0 -----------
Name                              Stmts   Miss  Cover
-----------------------------------------------------
promise/__init__.py                  11      0   100%
promise/async_.py                    84     10    88%
promise/dataloader.py               108      9    92%
promise/promise.py                  424     17    96%
promise/promise_list.py              84     13    85%
promise/pyutils/__init__.py           0      0   100%
promise/pyutils/version.py           42     18    57%
promise/schedulers/__init__.py        0      0   100%
promise/schedulers/asyncio.py        13     13     0%
promise/schedulers/gevent.py         14     14     0%
promise/schedulers/immediate.py      15      1    93%
promise/schedulers/thread.py         13     13     0%
-----------------------------------------------------
TOTAL                               808    108    87%

========== warnings summary ========================================
tests/test_awaitable_35.py::test_coroutine_is_thenable
  promise/tests/test_awaitable_35.py:26: RuntimeWarning: coroutine 'test_coroutine_is_thenable.<locals>.my_coroutine' was never awaited
    assert is_thenable(my_coroutine())

tests/test_extra.py::test_promises_promisify_still_works_but_deprecated_for_non_callables
  promise/promise.py:745: DeprecationWarning: Promise.promisify is now a function decorator, please use Promise.resolve instead.
    "Promise.promisify is now a function decorator, please use Promise.resolve instead."

-- Docs: http://doc.pytest.org/en/latest/warnings.html
=========== 114 passed, 9 skipped, 2 warnings in 2.26 seconds ======

```
Fixes Github issue #60