### PR TITLE
Fix Python 3.7 deprecation warnings

### DIFF
--- a/promise/dataloader.py
+++ b/promise/dataloader.py
@@ -1,4 +1,8 @@
-from collections import Iterable, namedtuple
+from collections import namedtuple
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from functools import partial
 
 from .promise import Promise, async_instance, get_default_scheduler

--- a/promise/promise_list.py
+++ b/promise/promise_list.py
@@ -1,5 +1,8 @@
 from functools import partial
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 if False:
     from .promise import Promise


### PR DESCRIPTION
Importing ABCs directly from the `collections` module is deprecated
in Python 3.7.