### PR TITLE
Make promise thread safety

### DIFF
--- a/promise/__init__.py
+++ b/promise/__init__.py
@@ -21,6 +21,7 @@ if not __SETUP__:
         promisify,
         is_thenable,
         async_instance,
+        async_lock,
         get_default_scheduler,
         set_default_scheduler,
     )
@@ -32,6 +33,7 @@ if not __SETUP__:
         "promisify",
         "is_thenable",
         "async_instance",
+        "async_lock",
         "get_default_scheduler",
         "set_default_scheduler",
         "ImmediateScheduler",

--- a/promise/dataloader.py
+++ b/promise/dataloader.py
@@ -1,7 +1,7 @@
 from collections import Iterable, namedtuple
 from functools import partial
 
-from .promise import Promise, async_instance, get_default_scheduler
+from .promise import Promise, async_lock, get_default_scheduler
 
 if False:
     from typing import (
@@ -225,7 +225,7 @@ def enqueue_post_promise_job(fn, scheduler):
 
     def on_promise_resolve(v):
         # type: (Any) -> None
-        async_instance.invoke(fn, scheduler)
+        async_lock.async_instance.invoke(fn, scheduler)
 
     resolved_promise.then(on_promise_resolve)  # type: Promise[None]
 

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -46,7 +46,7 @@ class AsyncThreadLocal(threading.local):
     @property
     def async_instance(self):
         # type: () -> Async
-        if not getattr(self, 'async_instance'):
+        if not getattr(self, '_async_instance'):
             self._async_instance = Async()
 
         return self._async_instance

--- a/promise/promise.py
+++ b/promise/promise.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from functools import partial, wraps
 from sys import version_info, exc_info
-from threading import RLock
+import threading
 from types import TracebackType
 
 from six import reraise  # type: ignore
@@ -37,9 +37,24 @@ if False:
     )
 
 
+class AsyncThreadLocal(threading.local):
+    """
+    The thread local class that make `async_instance` safe for threads.
+    """
+    _async_instance = None
+
+    @property
+    def async_instance(self):
+        # type: () -> Async
+        if not getattr(self, 'async_instance'):
+            self._async_instance = Async()
+
+        return self._async_instance
+
+
 default_scheduler = ImmediateScheduler()
 
-async_instance = Async()
+async_instance = AsyncThreadLocal().async_instance
 
 
 def get_default_scheduler():

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from promise import Promise, async_instance
+from promise import Promise, async_lock
 from promise.dataloader import DataLoader
 
 
@@ -426,9 +426,9 @@ def test_wrong_loader_return_type_does_not_block_async_instance():
 
         with raises(Exception):
             a_loader.load("A1").get()
-        assert async_instance.have_drained_queues
+        assert async_lock.async_instance.have_drained_queues
         with raises(Exception):
             a_loader.load("A2").get()
-        assert async_instance.have_drained_queues
+        assert async_lock.async_instance.have_drained_queues
 
     do().get()


### PR DESCRIPTION
Hi guys 🤚.
I had a problem with `dataloader` when I running my application in thread mode. Problem was connected with `async_instance` because share this variable between threads. About that also described here:

https://github.com/syrusakbary/promise/issues/57#issuecomment-445983988

This pull request solve current problem, but it's not perfect.
If u have some other better ideas how to fix that, so tell please and i'll try to do that.
This a big bug for me 😔 and i hope we solve that very quickly .
@syrusakbary 