### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_require = [
     "coveralls",
     "futures",
     "pytest-benchmark",
-    "mock",
+    "mock"
 ]
 if IS_PY3:
     tests_require += ["pytest-asyncio"]


### PR DESCRIPTION
I encountered the following build error when trying to install Promise as a dependency for Graphene:

```
 Downloading/unpacking promise>=2.1,<3 (from graphene==2.1.3->-r /var/app/requirements.txt (line 16))
    Downloading promise-2.2.1.tar.gz
    Running setup.py (path:/var/app/build/promise/setup.py) egg_info for package promise
      error in promise setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
      Complete output from command python setup.py egg_info:
      error in promise setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```
Perhaps this comma is the culprit?