### PR TITLE
Make dataloader keep cache object

### DIFF
--- a/promise/dataloader.py
+++ b/promise/dataloader.py
@@ -164,7 +164,7 @@ class DataLoader(object):
         invalidations across this particular `DataLoader`. Returns itself for
         method chaining.
         """
-        self._promise_cache = {}
+        self._promise_cache.clear()
         return self
 
     def prime(self, key, value):

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -202,6 +202,24 @@ def test_clears_all_values_in_loader():
     do().get()
 
 
+def test_does_not_replace_cache_map():
+    @Promise.safe
+    def do():
+        identity_loader, _ = id_loader()
+        a, b = Promise.all([identity_loader.load("A"), identity_loader.load("B")]).get()
+
+        assert a == "A"
+        assert b == "B"
+
+        cache_map = identity_loader._promise_cache
+
+        identity_loader.clear_all()
+
+        assert id(identity_loader._promise_cache) == id(cache_map)
+
+    do().get()
+
+
 def test_allows_priming_the_cache():
     @Promise.safe
     def do():


### PR DESCRIPTION
Use `self._promise_cache.clear()` instead of replacing the cache object with a dictionary to allow supplying the loader with a custom cache object