### PR TITLE
fix: make promise library threadsafe

### DIFF
--- a/promise/async_.py
+++ b/promise/async_.py
@@ -1,4 +1,5 @@
 # Based on https://github.com/petkaantonov/bluebird/blob/master/src/promise.js
+import threading
 from collections import deque
 
 if False:
@@ -6,7 +7,7 @@ if False:
     from typing import Any, Callable, Optional, Union  # flake8: noqa
 
 
-class Async(object):
+class Async(threading.local):
     def __init__(self, trampoline_enabled=True):
         self.is_tick_used = False
         self.late_queue = deque()  # type: ignore


### PR DESCRIPTION
Problem proof: https://gist.github.com/diverru/3b317313366311fc260707cc91e77994
relating problems: #57, #68, #70 
My solution is more lightweight than #70 

Also, i've found that graphql-core uses promises to handle whole graphql requests, it means that even with SyncExecutor whole graphql request could be handled by another unexpected thread.
It leads to huge security problems with global/singleton (even threadlocal) variables.