### PR TITLE
Make Promise and Dataloader thread-safe

### DIFF
--- a/promise/async_.py
+++ b/promise/async_.py
@@ -1,12 +1,13 @@
 # Based on https://github.com/petkaantonov/bluebird/blob/master/src/promise.js
 from collections import deque
+from threading import local
 
 if False:
     from .promise import Promise
     from typing import Any, Callable, Optional, Union  # flake8: noqa
 
 
-class Async(object):
+class Async(local):
     def __init__(self, trampoline_enabled=True):
         self.is_tick_used = False
         self.late_queue = deque()  # type: ignore

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -1,0 +1,115 @@
+from promise import Promise
+from promise.dataloader import DataLoader
+import threading
+
+
+
+def test_promise_thread_safety():
+    """
+    Promise tasks should never be executed in a different thread from the one they are scheduled from,
+    unless the ThreadPoolExecutor is used.
+
+    Here we assert that the pending promise tasks on thread 1 are not executed on thread 2 as thread 2 
+    resolves its own promise tasks.
+    """
+    event_1 = threading.Event()
+    event_2 = threading.Event()
+
+    assert_object = {'is_same_thread': True}
+
+    def task_1():
+        thread_name = threading.current_thread().getName()
+
+        def then_1(value): 
+          # Enqueue tasks to run later. 
+          # This relies on the fact that `then` does not execute the function synchronously when called from
+          # within another `then` callback function.
+          promise = Promise.resolve(None).then(then_2)
+          assert promise.is_pending
+          event_1.set()  # Unblock main thread
+          event_2.wait()  # Wait for thread 2 
+       
+        def then_2(value):
+          assert_object['is_same_thread'] = (thread_name == threading.current_thread().getName())
+
+        promise = Promise.resolve(None).then(then_1)
+
+    def task_2():
+        promise = Promise.resolve(None).then(lambda v: None)
+        promise.get()  # Drain task queue
+        event_2.set()  # Unblock thread 1
+
+    thread_1 = threading.Thread(target=task_1)
+    thread_1.start()
+
+    event_1.wait()  # Wait for Thread 1 to enqueue promise tasks
+
+    thread_2 = threading.Thread(target=task_2)  
+    thread_2.start()
+
+    for thread in (thread_1, thread_2):
+      thread.join()
+
+    assert assert_object['is_same_thread']
+
+
+def test_dataloader_thread_safety():
+    """
+    Dataloader should only batch `load` calls that happened on the same thread.
+    
+    Here we assert that `load` calls on thread 2 are not batched on thread 1 as
+    thread 1 batches its own `load` calls.
+    """
+    def load_many(keys):
+        thead_name = threading.current_thread().getName()
+        return Promise.resolve([thead_name for key in keys])
+
+    thread_name_loader = DataLoader(load_many)
+
+    event_1 = threading.Event()
+    event_2 = threading.Event()
+    event_3 = threading.Event()
+
+    assert_object = {
+      'is_same_thread_1': True,
+      'is_same_thread_2': True,
+    }
+
+    def task_1():
+        @Promise.safe
+        def do():
+            promise = thread_name_loader.load(1)
+            event_1.set()
+            event_2.wait()  # Wait for thread 2 to call `load`
+            assert_object['is_same_thread_1'] = (
+              promise.get() == threading.current_thread().getName()
+            )
+            event_3.set()  # Unblock thread 2
+
+        do().get()
+
+    def task_2():
+        @Promise.safe
+        def do():
+            promise = thread_name_loader.load(2)
+            event_2.set()
+            event_3.wait()  # Wait for thread 1 to run `dispatch_queue_batch`
+            assert_object['is_same_thread_2'] = (
+              promise.get() == threading.current_thread().getName()
+            )
+            
+        do().get()
+
+    thread_1 = threading.Thread(target=task_1)
+    thread_1.start()
+
+    event_1.wait() # Wait for thread 1 to call `load`
+
+    thread_2 = threading.Thread(target=task_2)  
+    thread_2.start()
+
+    for thread in (thread_1, thread_2):
+      thread.join()
+
+    assert assert_object['is_same_thread_1']
+    assert assert_object['is_same_thread_2']


### PR DESCRIPTION
Hi @syrusakbary,

This fixes the thread-safety issues in Promise and Dataloader that have been reported by https://github.com/syrusakbary/promise/pull/80, https://github.com/syrusakbary/promise/pull/70 and https://github.com/syrusakbary/promise/issues/68. These are major security issues that are potentially impacting all Graphql servers that run in threaded mode, including all wsgi applications (see [reproduction](https://github.com/jnak/graphql-core/commit/4cef0373cdf3162668b80b1c0932548131f6c253)).

**1. Promise issue**

Currently promise tasks (ie `then` functions) can be executed on a different thread from the one they were scheduled on. If the tasks rely on any thread-scoped global variables such as [Flask's](https://flask.palletsprojects.com/en/1.0.x/appcontext/) or [Django's](https://django-globals.readthedocs.io/en/latest/) contexts, the tasks will be executed with incorrect values. For example, a GraphQL `viewer` field may resolve to the wrong logged-in user and may expose very sensitive informations. You can reproduce the issue by running the test `test_promise_thread_safety` on master. 

**2. Dataloader issue**

Currently Dataloader batches `load` calls from different threads on one single thread. While it seems it could be a good idea to globally batch `load` calls, this currently leads to same hard-to-reproduce concurrency bugs. For example, Dataloader will run all the `load` promises on the thread that happens to run `dispatch_queue_batch`, causing the same issue as #1. You can reproduce the issue by running the test `test_dataloader_thread_safety` on master.

**Next steps**

It is critical that we release this patch as soon as possible since all GraphQL servers running in threaded-mode are currently impacted (see [reproduction](https://github.com/jnak/graphql-core/commit/4cef0373cdf3162668b80b1c0932548131f6c253)).

Even though all the tests pass on this branch, the build is currently failing due to some mypy errors. If you wish to have build errors resolved before merging this, I recommend you first merge https://github.com/syrusakbary/promise/pull/79 since it is very safe to merge and it fixes all those lint issues. I [rebased my changes](https://github.com/jnak/promise/tree/concurrency-bug-2) on top of that branch to make sure the build will pass.

Please let me know what I can do to help get this released as fast as possible.

Thanks,
J