### PR TITLE
read traceback from target promise

### DIFF
--- a/promise/promise_list.py
+++ b/promise/promise_list.py
@@ -130,7 +130,7 @@ class PromiseList(object):
         # assert not self.is_resolved
         # assert isinstance(self._values, Iterable)
         self._total_resolved += 1
-        self._reject(reason, traceback=promise._traceback)
+        self._reject(reason, traceback=promise._target()._traceback)
         return True
 
     @property


### PR DESCRIPTION
Sometimes, a promise is followed by other promise.
So it should read traceback from the target promise.

related: #85 