### PR TITLE
Fix tests for pytest 7.0 compatibility

### DIFF
--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -113,7 +113,7 @@ def test_thrown_exceptions_have_stacktrace():
     with raises(AssertionError) as assert_exc:
         p3.get()
 
-    assert assert_exc.traceback[-1].path.strpath == __file__
+    assert str(assert_exc.traceback[-1].path) == __file__
 
 
 def test_thrown_exceptions_preserve_stacktrace():
@@ -127,7 +127,7 @@ def test_thrown_exceptions_preserve_stacktrace():
     with raises(AssertionError) as assert_exc:
         p3.get()
 
-    assert assert_exc.traceback[-1].path.strpath == __file__
+    assert str(assert_exc.traceback[-1].path) == __file__
 
 
 # WAIT


### PR DESCRIPTION
The `path` attribute of `Traceback` objects was changed to `pathlib.Path` in pytest 7.0 (this can be tested with `7.0.0rc1`).

This changes the affected code so it will work with pytest 7.0 and previous versions too.

Ref: https://github.com/pytest-dev/pytest/discussions/9415#discussioncomment-1834432